### PR TITLE
Refactor `earliestTimeSlot` function to handle empty arrays

### DIFF
--- a/src/app/persons/services/person.service.ts
+++ b/src/app/persons/services/person.service.ts
@@ -86,18 +86,19 @@ export class PersonService {
   }
 
 
-  public earliestTimeSlot(person: Person): PersonTimeSlot {
-    // TODO: Fix reduce for cases when dealing with an empty Array.
+  public earliestTimeSlot(person: Person): PersonTimeSlot | undefined {
     return person.timeSlots
       .filter(s => s.priority === 1)
-      .reduce((smallest, current) => {
+      .reduce((smallest: PersonTimeSlot | undefined, current) => {
+        if (!smallest) return current;
+
         return smallest.timeSlot.start.compareTo(current.timeSlot.start) < 0 ? smallest : current
-      });
+      }, undefined);
   }
 
 
   public earliestStartTime(person: Person): Time {
-    return this.earliestTimeSlot(person).timeSlot.start;
+    return this.earliestTimeSlot(person)?.timeSlot.start || new Time(9, 0);
   }
 
 


### PR DESCRIPTION
The pull request includes updates for handling empty arrays in the `earliestTimeSlot` function. Refactored to return `undefined` when no valid slots are found and adjusted `earliestStartTime` for default fallback time.